### PR TITLE
iOS 3 Support and Stop Reason Access

### DIFF
--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -183,6 +183,7 @@ extern NSString * const ASUpdateMetadataNotification;
 
 @property AudioStreamerErrorCode errorCode;
 @property (readonly) AudioStreamerState state;
+@property (readonly) AudioStreamerStopReason stopReason;
 @property (readonly) double progress;
 @property (readonly) double bufferFillPercentage;
 @property (readonly) double duration;


### PR DESCRIPTION
Thanks for your awesome port of AudioStreamer! I was using the original source from Matt Gallagher's, but needed iOS 4 backgrounding and came across yours. There are two tweaks in this pull. I had made a minor tweak to the original AudioStreamer source which made the stop reason available outside of the AudioStreamer instance (a simple synthesized readonly property). Which was easy to implement in your port. The other change  was to move around / check for compatibility with iOS 3 and UIBackgroundTask. After testing on a 2nd gen iPhone running 3.1.3 and a 3GS running 4.1.2 I can confidently say it is working. This should also clear up one of the issues in your queue.
