### PR TITLE
I added some features into the AudioStreamer

### DIFF
--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -11,7 +11,7 @@
 //  this copyright and permission notice. Attribution in compiled projects is
 //  appreciated but not required.
 //
-#define SHOUTCAST_METADATA
+//#define SHOUTCAST_METADATA
 
 #if TARGET_OS_IPHONE			
 #import <UIKit/UIKit.h>

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -11,7 +11,7 @@
 //  this copyright and permission notice. Attribution in compiled projects is
 //  appreciated but not required.
 //
-//#define SHOUTCAST_METADATA
+#define SHOUTCAST_METADATA
 
 #if TARGET_OS_IPHONE			
 #import <UIKit/UIKit.h>
@@ -26,8 +26,8 @@
 #include <pthread.h>
 #include <AudioToolbox/AudioToolbox.h>
 
-//#import "encryption.h" //custom encryption support
-#import <zlib.h>
+
+#define USE_PREBUFFER 1
 
 
 #define LOG_QUEUED_BUFFERS 0
@@ -185,16 +185,12 @@ extern NSString * const ASUpdateMetadataNotification;
 #endif
 	BOOL vbr; // indicates VBR (or not) stream
     
-//    EncryptionMethod _encryption;//加密方式
-    uLong _crc32;
-    void * _encryptionSampledBuffer; //加密用缓冲
-    NSUInteger _encryptionOffset;
-    
+
+#if defined (USE_PREBUFFER) && USE_PREBUFFER
     NSLock * _bufferLock;
     NSMutableArray * _buffers;
     NSThread * _bufferPushingThread;
-    
-    NSTimeInterval _lastTimeInterval;
+#endif
 }
 
 @property AudioStreamerErrorCode errorCode;

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -11,7 +11,7 @@
 //  this copyright and permission notice. Attribution in compiled projects is
 //  appreciated but not required.
 //
-#define SHOUTCAST_METADATA
+//#define SHOUTCAST_METADATA
 
 #if TARGET_OS_IPHONE			
 #import <UIKit/UIKit.h>
@@ -20,11 +20,15 @@
 #endif
 #else
 #import <Cocoa/Cocoa.h>
-#endif TARGET_OS_IPHONE			
+#endif// TARGET_OS_IPHONE			
 
 #import <Foundation/Foundation.h>
 #include <pthread.h>
 #include <AudioToolbox/AudioToolbox.h>
+
+//#import "encryption.h" //custom encryption support
+#import <zlib.h>
+
 
 #define LOG_QUEUED_BUFFERS 0
 
@@ -98,7 +102,8 @@ typedef enum
 	AS_AUDIO_QUEUE_FLUSH_FAILED,
 	AS_AUDIO_STREAMER_FAILED,
 	AS_GET_AUDIO_TIME_FAILED,
-	AS_AUDIO_BUFFER_TOO_SMALL
+	AS_AUDIO_BUFFER_TOO_SMALL,
+    AS_AUDIO_MEMORY_ALLOC_FAILED,
 } AudioStreamerErrorCode;
 
 extern NSString * const ASStatusChangedNotification;
@@ -179,6 +184,17 @@ extern NSString * const ASUpdateMetadataNotification;
 	NSMutableString *metaDataString;			// the metaDataString
 #endif
 	BOOL vbr; // indicates VBR (or not) stream
+    
+//    EncryptionMethod _encryption;//加密方式
+    uLong _crc32;
+    void * _encryptionSampledBuffer; //加密用缓冲
+    NSUInteger _encryptionOffset;
+    
+    NSLock * _bufferLock;
+    NSMutableArray * _buffers;
+    NSThread * _bufferPushingThread;
+    
+    NSTimeInterval _lastTimeInterval;
 }
 
 @property AudioStreamerErrorCode errorCode;
@@ -194,6 +210,7 @@ extern NSString * const ASUpdateMetadataNotification;
 @property (readonly) BOOL vbr;
 
 - (id)initWithURL:(NSURL *)aURL;
+//- (id)initWithURL:(NSURL *)aURL encryption:(EncryptionMethod)method crc32:(uLong)crc32;
 - (void)start;
 - (void)stop;
 - (void)pause;
@@ -209,6 +226,7 @@ extern NSString * const ASUpdateMetadataNotification;
 - (float)averagePowerForChannel:(NSUInteger)channelNumber;
 
 
+- (void)setVolume:(float)vol;
 @end
 
 

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -188,6 +188,7 @@ extern NSString * const ASUpdateMetadataNotification;
 
 #if defined (USE_PREBUFFER) && USE_PREBUFFER
     NSLock * _bufferLock;
+    NSLock * _audioStreamLock;
     NSMutableArray * _buffers;
     NSThread * _bufferPushingThread;
     BOOL _allBufferPushed;

--- a/Classes/AudioStreamer.h
+++ b/Classes/AudioStreamer.h
@@ -190,6 +190,8 @@ extern NSString * const ASUpdateMetadataNotification;
     NSLock * _bufferLock;
     NSMutableArray * _buffers;
     NSThread * _bufferPushingThread;
+    BOOL _allBufferPushed;
+    BOOL _finishedBuffer;
 #endif
 }
 

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -937,7 +937,7 @@ cleanup:
 		// Close the audio file strea,
 		//
 
-//MUST divde @synchronized(self) {} into two blocks, 
+//MUST divde @synchronized(self) {} into two blocks , 
 //or it will run in dead lock
 //use a audioStreamLock is to prevent audio stream is closed when pushDataThread is pushing data
         [_audioStreamLock lock];
@@ -1782,12 +1782,13 @@ cleanup:
             [_buffers addObject:data];
             [_bufferLock unlock];
             [data release];
-            
+           @synchronized(self) { 
             if (nil == _bufferPushingThread) {
                 _bufferPushingThread = [[NSThread alloc] initWithTarget:self selector:@selector(pushingBufferThread:) object:nil];
                 [_bufferPushingThread setName:@"Push/Parse Buffer Thread"];
                 [_bufferPushingThread start];
             }
+           }
         }
 		else {
 #endif
@@ -1863,11 +1864,12 @@ cleanup:
             [_buffers addObject:data];
             [_bufferLock unlock];
             [data release];
-            
-            if (nil == _bufferPushingThread) {
-                _bufferPushingThread = [[NSThread alloc] initWithTarget:self selector:@selector(pushingBufferThread:) object:nil];
-                [_bufferPushingThread setName:@"Push/Parse Buffer Thread"];
-                [_bufferPushingThread start];
+            @synchronized(self) { 
+                if (nil == _bufferPushingThread) {
+                    _bufferPushingThread = [[NSThread alloc] initWithTarget:self selector:@selector(pushingBufferThread:) object:nil];
+                    [_bufferPushingThread setName:@"Push/Parse Buffer Thread"];
+                    [_bufferPushingThread start];
+                }
             }
         }
 		else {
@@ -2019,7 +2021,9 @@ cleanup:
             [inpool drain];
         }
         self.allBufferPushed = YES;
-        RELEASE_SAFELY(_bufferPushingThread);
+        @synchronized(self) { 
+            RELEASE_SAFELY(_bufferPushingThread);
+        }
     }
     
     [pool drain];

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -932,10 +932,14 @@ cleanup:
 			CFRelease(stream);
 			stream = nil;
 		}
-		
+    }
 		//
 		// Close the audio file strea,
 		//
+
+//MUST divde @synchronized(self) {} into two blocks, 
+//or it will run in dead lock
+//use a audioStreamLock is to prevent audio stream is closed when pushDataThread is pushing data
         [_audioStreamLock lock];
 		if (audioFileStream)
 		{
@@ -947,7 +951,8 @@ cleanup:
 			}
 		}
         [_audioStreamLock unlock];
-		
+    @synchronized(self)
+    {
 		//
 		// Dispose of the Audio Queue
 		//

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -2017,10 +2017,12 @@ cleanup:
                     }
                 }
                 else {
-                    [NSThread sleepForTimeInterval:0.01];
+//                    [NSThread sleepForTimeInterval:0.01];
                 }
             }
             [inpool drain];
+            
+            [NSThread sleepForTimeInterval:0.01];
         }
         self.allBufferPushed = YES;
         @synchronized(self) { 

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -934,6 +934,7 @@ cleanup:
 		//
 		// Close the audio file strea,
 		//
+        @synchronized(_bufferLock) {
 		if (audioFileStream)
 		{
 			err = AudioFileStreamClose(audioFileStream);
@@ -943,6 +944,7 @@ cleanup:
 				[self failWithErrorCode:AS_FILE_STREAM_CLOSE_FAILED];
 			}
 		}
+        }
 		
 		//
 		// Dispose of the Audio Queue
@@ -1791,7 +1793,9 @@ cleanup:
 			if (lengthNoMetaData > 0)
 			{
 				//NSLog(@"Parsing no meta bytes (Discontinuous).");
+                @synchronized(_bufferLock) {
 				err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, kAudioFileStreamParseFlag_Discontinuity);
+                }
 				if (err)
 				{
 					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1801,7 +1805,9 @@ cleanup:
 			else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
 			{
 				//NSLog(@"Parsing normal bytes (Discontinuous).");
+                @synchronized(_bufferLock) {
 				err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
+                }
 				if (err)
 				{
 					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1814,7 +1820,9 @@ cleanup:
 			if (lengthNoMetaData > 0)
 			{
 				//NSLog(@"Parsing no meta bytes.");
+                @synchronized(_bufferLock) {
 				err = AudioFileStreamParseBytes(audioFileStream, lengthNoMetaData, bytesNoMetaData, 0);
+                }
 				if (err)
 				{
 					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1824,7 +1832,9 @@ cleanup:
 			else if (metaDataInterval == 0)	// make sure this isn't a stream with metadata
 			{
 				//NSLog(@"Parsing normal bytes.");
+                @synchronized(_bufferLock) {
 				err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
+                }
 				if (err)
 				{
 					[self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1855,7 +1865,9 @@ cleanup:
 #endif
             if (discontinuous)
             {
+                @synchronized(_bufferLock) {
                 err = AudioFileStreamParseBytes(audioFileStream, length, bytes, kAudioFileStreamParseFlag_Discontinuity);
+                }
                 if (err)
                 {
                     [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1864,7 +1876,9 @@ cleanup:
             }
             else
             {
+                @synchronized(_bufferLock) {
                 err = AudioFileStreamParseBytes(audioFileStream, length, bytes, 0);
+                }
                 if (err)
                 {
                     [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1900,7 +1914,9 @@ cleanup:
                 if (data) {
                     if (discontinuous)
                     {
+                        @synchronized(_bufferLock) {
                         err = AudioFileStreamParseBytes(audioFileStream, data.length, data.bytes, kAudioFileStreamParseFlag_Discontinuity);
+                        }
                         if (err)
                         {
                             [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];
@@ -1909,7 +1925,9 @@ cleanup:
                     }
                     else
                     {
+                        @synchronized(_bufferLock) {
                         err = AudioFileStreamParseBytes(audioFileStream, data.length, data.bytes, 0);
+                        }
                         if (err)
                         {
                             [self failWithErrorCode:AS_FILE_STREAM_PARSE_BYTES_FAILED];

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -1282,7 +1282,7 @@ cleanup:
 {
 	@synchronized(self)
 	{
-		if (state == AS_PLAYING)
+		if (state == AS_PLAYING || state == AS_BUFFERING) //if is buffering, the user pauses it
 		{
 			err = AudioQueuePause(audioQueue);
 			if (err)

--- a/Classes/AudioStreamer.m
+++ b/Classes/AudioStreamer.m
@@ -1871,6 +1871,8 @@ cleanup:
                     [_bufferPushingThread start];
                 }
             }
+            //maybe the runloop runs too fast ,that _bufferPushingThread is frequently blocked before the streaing is pre-buffered.
+            [NSThread sleepForTimeInterval:0.01];
         }
 		else {
 #endif


### PR DESCRIPTION
1. added a local file streaming support
2. added prebuffer feature (with macro to turn it on/off). prebuffer song streaming into a buffer array, and start a new thread to push buffer into audio queue. I added it mainly for iOS. I encountered a situation, the network is not stable, if using CFReadStream, it requires the network is always reliable during playing. using prebuffer, all stream is burst buffered into a buffer array, it only needs a burst network access.
3. fixed a bug: reset ivar stream to NULL, when openReadStream failed.
4. remove a statement in -(void)stop, which will cause 'iuhw' error to audio queue when quickly stop streamer.
5. a -(void)setVolume method
